### PR TITLE
ci: add Catalog CI workflow

### DIFF
--- a/.github/workflows/catalog-ci.yml
+++ b/.github/workflows/catalog-ci.yml
@@ -1,0 +1,48 @@
+name: Catalog CI
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'Services/Catalog/**'
+      - '.github/workflows/catalog-ci.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'Services/Catalog/**'
+      - '.github/workflows/catalog-ci.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    env:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      ASPNETCORE_ENVIRONMENT: Test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET (with NuGet cache)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+          cache: true
+          cache-dependency-path: |
+            **/*.sln
+            **/*.csproj
+            **/packages.lock.json
+            **/nuget.config
+
+      - name: Restore
+        run: dotnet restore Services/Catalog/Catalog.sln
+
+      - name: Build
+        run: dotnet build Services/Catalog/Catalog.sln --no-restore -c Release
+
+      - name: Test
+        run: dotnet test Services/Catalog/Catalog.sln --no-build -c Release


### PR DESCRIPTION
- Added a GitHub Actions workflow for the Catalog service.
- Workflow runs on push or PR changes to 'Services/Catalog/**'.
- Includes NuGet cache, build, and test steps for faster CI.